### PR TITLE
pasrsing error in instrumentation-client.js

### DIFF
--- a/apps/web/instrumentation-client.js
+++ b/apps/web/instrumentation-client.js
@@ -1,6 +1,6 @@
 import posthog from "posthog-js"
 
-posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
+posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
   api_host: "/ingest",
   ui_host: "https://us.posthog.com",
   defaults: '2025-05-24',


### PR DESCRIPTION
I noticed that you already fixed the contributors page, so no change required up there. However the `instrumentation-client.js` was throwing parsing error.  I think we also need to update READEME.md accordingly.

closing #16 

```
Parsing ecmascript source code failed
  1 | import posthog from "posthog-js"
  2 |
> 3 | posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
    |                                                 ^
  4 |   api_host: "/ingest",
  5 |   ui_host: "https://us.posthog.com",
  6 |   defaults: '2025-05-24',

Expected ',', got '!'
```