### PR TITLE
Fix notification icon overflow

### DIFF
--- a/apps/web/src/components/notifications/notifications-dropdown.tsx
+++ b/apps/web/src/components/notifications/notifications-dropdown.tsx
@@ -163,7 +163,7 @@ export function NotificationsDropdown({
           <div className={cn('relative cursor-pointer', triggerClassName)}>
             {children}
             {unreadCount > 0 && (
-              <div className="absolute -top-0.5 -right-0.5 h-2 w-2 rounded-full bg-[#6CFF00]" />
+              <div className="absolute top-0.5 right-0.5 h-2 w-2 rounded-full bg-[#6CFF00]" />
             )}
           </div>
         ) : (


### PR DESCRIPTION
## Summary
Adjusted notification icon positioning to prevent overflow when sidebar is collapsed. Modified the absolute positioning of the unread notification indicator to ensure it stays within the sidebar icon's bounds.

### Changes
- Updated CSS positioning of notification indicator
  - Changed `-top-0.5 -right-0.5` to `top-0.5 right-0.5` to keep the indicator contained 
  


 <br /> 


 > Want tembo to make any changes? Add a review or comment with `@tembo` and i'll get back to work! 


 [![tembo.io](https://internal.tembo.io/static/view/tembo.svg?v=4)](https://app.tembo.io/tasks/92390b6e-0197-4fa4-a77a-6015393fbe7f)  [![app.tembo.io](https://internal.tembo.io/public/agent-button/claudeCode:claude-4-5-sonnet?v=1)](https://app.tembo.io/settings/agents)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed unread notification badge overflow in the collapsed sidebar by adjusting its position to stay within the icon bounds.

Switched absolute offsets from -top-0.5/-right-0.5 to top-0.5/right-0.5.

<sup>Written for commit 0d798209a9656edde1f3842692cde5b93d1f0093. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Repositioned the unread notification indicator in the notifications dropdown for improved visual alignment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->