### PR TITLE
Improve landing demo: align bounty bot commands

### DIFF
--- a/apps/web/src/components/landing/approve-pay-demo.tsx
+++ b/apps/web/src/components/landing/approve-pay-demo.tsx
@@ -317,7 +317,7 @@ function PRCommentsPage({
                   <a href="#" className="text-gh-error-text hover:underline">
                     @bountydotnew
                   </a>{' '}
-                  /approve
+                  approve
                 </p>
               </div>
               <div className="px-4 pb-3 flex items-center gap-2">
@@ -383,9 +383,9 @@ function PRCommentsPage({
                   Approved. When you're ready, merge the PR and confirm here
                   with{' '}
                   <code className="bg-gh-surface px-1.5 py-0.5 rounded text-xs">
-                    /merge 47
+                    @bountydotnew merge
                   </code>{' '}
-                  (or comment{' '}
+                  (after merge, confirm payout by commenting{' '}
                   <a href="#" className="text-gh-error-text hover:underline">
                     @bountydotnew
                   </a>{' '}

--- a/apps/web/src/components/landing/create-bounty-demo.tsx
+++ b/apps/web/src/components/landing/create-bounty-demo.tsx
@@ -748,20 +748,24 @@ function GitHubIssuePage({
               </p>
               <div className="bg-gh-surface border border-gh-border rounded-md p-3 text-gh-text-secondary text-xs">
                 <p>
-                  <strong className="text-gh-text">
-                    To claim this bounty:
-                  </strong>
+                  <strong className="text-gh-text">To claim this bounty:</strong>
                 </p>
                 <ol className="list-decimal list-inside mt-2 space-y-1">
                   <li>Submit a pull request that fixes this issue</li>
                   <li>
-                    Comment{' '}
+                    Include{' '}
                     <code className="px-1.5 py-0.5 bg-gh-border rounded">
-                      /submit #PR_NUMBER
+                      @bountydotnew submit
                     </code>{' '}
-                    on this issue
+                    in your PR description
                   </li>
-                  <li>Wait for the maintainer to approve your solution</li>
+                  <li>Wait for the maintainer to review + merge your PR</li>
+                  <li>
+                    After merge, confirm payout with{' '}
+                    <code className="px-1.5 py-0.5 bg-gh-border rounded">
+                      @bountydotnew merge
+                    </code>
+                  </li>
                 </ol>
               </div>
             </div>

--- a/apps/web/src/components/landing/submit-solution-demo.tsx
+++ b/apps/web/src/components/landing/submit-solution-demo.tsx
@@ -153,9 +153,9 @@ function GitHubIssuePage() {
               <p className="text-gh-text-muted text-xs mt-2">
                 Submit your solution with{' '}
                 <code className="bg-gh-surface px-1.5 py-0.5 rounded">
-                  @bountydotnew /submit
+                  @bountydotnew submit
                 </code>{' '}
-                in your PR
+                in your PR description
               </p>
             </div>
             <div className="px-4 pb-3 flex items-center gap-2">
@@ -227,7 +227,7 @@ function GitHubIssuePage() {
           <div className="flex-1">
             <div className="border border-gh-border rounded-md">
               <textarea
-                value="@bountydotnew /submit #47"
+                value="@bountydotnew submit #47"
                 readOnly
                 rows={2}
                 className="w-full bg-gh-bg px-4 py-3 text-gh-text focus:outline-none font-mono text-sm resize-none"


### PR DESCRIPTION
Fixes #164

This updates the landing page interactive demos to match the current bounty.new workflow:
- use `@bountydotnew submit` (no slash)
- clarify that submission keyword goes in the PR description
- use `@bountydotnew merge` for payout confirmation after merge

@bountydotnew submit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bounty Process Updates**
  * Updated bounty submission commands and workflow instructions for improved user experience and clarity throughout the entire submission and payout process
  * Refined step-by-step guidance covering bounty submission, maintainer review, merge confirmation, and payout verification
  * Simplified user-facing text to make interactions with the bounty system more straightforward and intuitive

<!-- end of auto-generated comment: release notes by coderabbit.ai -->