### PR TITLE
Fix review comments

### DIFF
--- a/apps/web/src/app/api/webhooks/github/route.ts
+++ b/apps/web/src/app/api/webhooks/github/route.ts
@@ -2818,7 +2818,7 @@ async function handleInstallationEvent(event: InstallationEvent) {
           installation.repository_selection === 'all' ? 'Organization' : 'User',
         accountAvatarUrl: installation.account.avatar_url || null,
         repositoryIds: repos.repositories.map((r) => String(r.id)),
-        organizationId: installerOrgId,
+        organizationId: installerOrgId ?? null,
       })
       .onConflictDoUpdate({
         target: githubInstallation.githubInstallationId,

--- a/apps/web/src/app/api/webhooks/resend/route.ts
+++ b/apps/web/src/app/api/webhooks/resend/route.ts
@@ -111,7 +111,7 @@ async function handleEmailReceived(event: EmailReceivedEvent) {
     from,
     to,
     subject,
-    attachmentCount: attachments.length,
+    attachmentCount: attachments?.length ?? 0,
   });
 
   // Fetch full email content (body, headers)

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -183,12 +183,15 @@ async function createPersonalTeam(user: {
   email: string;
   handle?: string | null;
 }) {
-  const handle =
+  const derivedHandle =
     (user as { handle?: string | null }).handle ??
     user.email
       .split('@')[0]
       ?.toLowerCase()
       .replace(/[^a-z0-9-]/g, '-');
+
+  const handle =
+    derivedHandle && !isReservedSlug(derivedHandle) ? derivedHandle : null;
 
   // Always suffix the slug with a random string so personal team slugs
   // never collide with each other or with reserved routes.


### PR DESCRIPTION
BOUNTY.NEW

## Summary
- Fixed `organizationId` to allow `null` in GitHub installation webhook handler
- Added null-safe check for `attachments?.length ?? 0` in Resend webhook
- Updated Linear OAuth account deletion to only remove account if no other `linearAccount` rows reference it
- Added `organizationId` check when verifying existing Linear workspace records
- Fixed personal team handle generation to check for reserved slugs and return `null` if reserved 
  


 <br /> 


 > Want tembo to make any changes? Add a review or comment with `@tembo` and i'll get back to work! 


 <a href="https://app.tembo.io/tasks/d81667b0-aa3b-46e5-9f1f-506d909ee5e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/static/view/tembo-dark.png?v=2"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/static/view/tembo-light.png?v=2"><img alt="View on Tembo" src="https://internal.tembo.io/static/view/tembo-light.png?v=2" width="134" height="28"></picture></a> <a href="https://app.tembo.io/settings/agents"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/agent-button/claudeCode:claude-opus-4-6?theme=dark&v=11"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/agent-button/claudeCode:claude-opus-4-6?theme=light&v=11"><img alt="View Agent Settings" src="https://internal.tembo.io/public/agent-button/claudeCode:claude-opus-4-6?theme=light&v=11" height="28"></picture></a> 