### PR TITLE
Remove invalid className prop

### DIFF
--- a/apps/web/src/components/auth/account-switcher.tsx
+++ b/apps/web/src/components/auth/account-switcher.tsx
@@ -174,7 +174,7 @@ export function AccountSwitcher({
 
   if (trigger) {
     return (
-      <Popover className="p-0" open={popoverOpen} onOpenChange={setPopoverOpen}>
+      <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
         <PopoverTrigger asChild>{trigger}</PopoverTrigger>
         {content}
       </Popover>


### PR DESCRIPTION
🦞

BOUNTY.NEW

## Summary
Removed invalid `className="p-0"` prop from `<Popover>` component in `account-switcher.tsx` as the Popover component does not accept a className prop, fixing TypeScript build error.

🦞 
  


 <br /> 


 > Want tembo to make any changes? Add a review or comment with `@tembo` and i'll get back to work! 


 <a href="https://app.tembo.io/tasks/afcdf9df-47cf-4390-8408-c45178a512a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/static/view/tembo-dark.png?v=2"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/static/view/tembo-light.png?v=2"><img alt="View on Tembo" src="https://internal.tembo.io/static/view/tembo-light.png?v=2" width="134" height="28"></picture></a> <a href="https://app.tembo.io/settings/agents"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/agent-button/claudeCode:claude-opus-4-6?theme=dark&v=11"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/agent-button/claudeCode:claude-opus-4-6?theme=light&v=11"><img alt="View Agent Settings" src="https://internal.tembo.io/public/agent-button/claudeCode:claude-opus-4-6?theme=light&v=11" height="28"></picture></a> 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted spacing in the account switcher popover by removing explicit padding styling, allowing default spacing to apply.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->