### PR TITLE
Fix mobile dashboard overflow

### DIFF
--- a/apps/web/src/components/dashboard/task-form/components/DescriptionTextarea.tsx
+++ b/apps/web/src/components/dashboard/task-form/components/DescriptionTextarea.tsx
@@ -17,7 +17,7 @@ export function DescriptionTextarea({
     if (textareaRef.current) {
       const textarea = textareaRef.current;
       textarea.style.height = 'auto';
-      const newHeight = Math.min(Math.max(textarea.scrollHeight, 160), 600);
+      const newHeight = Math.min(Math.max(textarea.scrollHeight, 100), 600);
       textarea.style.height = `${newHeight}px`;
     }
   });
@@ -39,11 +39,11 @@ export function DescriptionTextarea({
             field.onChange(e.target.value);
             const target = e.target;
             target.style.height = 'auto';
-            const newHeight = Math.min(Math.max(target.scrollHeight, 160), 600);
+            const newHeight = Math.min(Math.max(target.scrollHeight, 100), 600);
             target.style.height = `${newHeight}px`;
           }}
           placeholder={placeholder}
-          className="flex-1 min-h-[160px] bg-transparent text-foreground text-[16px] leading-6 outline-none resize-none placeholder:text-text-tertiary"
+          className="flex-1 min-h-[100px] bg-transparent text-foreground text-[16px] leading-6 outline-none resize-none placeholder:text-text-tertiary"
         />
       )}
     />

--- a/apps/web/src/components/dashboard/task-form/components/RepoBranchIssueSelector.tsx
+++ b/apps/web/src/components/dashboard/task-form/components/RepoBranchIssueSelector.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useRef } from 'react';
 import { ChevronRight, ChevronLeft, Check, Loader2 } from 'lucide-react';
 import { GithubIcon, BranchIcon } from '@bounty/ui';
+import { IssueOpenedIcon } from '@bounty/ui/components/icons/huge/issue-opened';
 import { ChevronSortIcon } from '@bounty/ui/components/icons/huge/chevron-sort';
 import {
   DropdownMenu,
@@ -1058,7 +1059,6 @@ function DesktopBranchDropdown({
           )}
         >
           <BranchIcon className="w-3.5 h-3.5" />
-          <span className="text-[14px] text-text-muted">{selectedBranch}</span>
           <ChevronSortIcon className="size-2" />
         </button>
       </DropdownMenuTrigger>
@@ -1110,10 +1110,7 @@ function DesktopIssueDropdown({
             issuesOpen && 'bg-white/10'
           )}
         >
-          <GithubIcon className="w-3.5 h-3.5" />
-          <span className="text-[14px] text-text-muted">
-            {selectedIssue ? `#${selectedIssue.number}` : 'Issue'}
-          </span>
+          <IssueOpenedIcon className="w-3.5 h-3.5" />
           <ChevronSortIcon className="size-2" />
         </button>
       </DropdownMenuTrigger>
@@ -1240,9 +1237,6 @@ function MobileDrawerView({
                 )}
               >
                 <BranchIcon className="w-3.5 h-3.5" />
-                <span className="text-[14px] text-text-muted">
-                  {selectedBranch}
-                </span>
                 <ChevronSortIcon className="size-2" />
               </button>
             </>
@@ -1264,10 +1258,7 @@ function MobileDrawerView({
                   mobileOpen && mobileStep === 'issues' && 'bg-white/10'
                 )}
               >
-                <GithubIcon className="w-3.5 h-3.5" />
-                <span className="text-[14px] text-text-muted">
-                  {selectedIssue ? `#${selectedIssue.number}` : 'Issue'}
-                </span>
+                <IssueOpenedIcon className="w-3.5 h-3.5" />
                 <ChevronSortIcon className="size-2" />
               </button>
             </>

--- a/apps/web/src/components/dashboard/task-input-form.tsx
+++ b/apps/web/src/components/dashboard/task-input-form.tsx
@@ -288,7 +288,7 @@ export const TaskInputForm = forwardRef<TaskInputFormRef, TaskInputFormProps>(
                 <div className="flex flex-row flex-wrap items-center gap-[5px]">
                   <TitleChip control={control} />
                   <PriceChip control={control} />
-                  <DeadlineChip control={control} />
+                  {/* <DeadlineChip control={control} /> */}
 
                   {/* Currency selector - hidden but kept for form */}
                   <Controller

--- a/packages/ui/src/components/icons/huge/index.ts
+++ b/packages/ui/src/components/icons/huge/index.ts
@@ -42,3 +42,4 @@ export * from './clock';
 export * from './file';
 export * from './hourglass';
 export * from './switch-arrows';
+export * from './issue-opened';

--- a/packages/ui/src/components/icons/huge/issue-opened.tsx
+++ b/packages/ui/src/components/icons/huge/issue-opened.tsx
@@ -1,0 +1,15 @@
+import type React from 'react';
+
+export const IssueOpenedIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 16 16"
+    width="16"
+    height="16"
+    fill="currentColor"
+    xmlns="http://www.w3.org/2000/svg"
+    {...props}
+  >
+    <path d="M8 9.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z" />
+    <path d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Z" />
+  </svg>
+);


### PR DESCRIPTION
🦞

BOUNTY.NEW

## Summary
Fixed mobile dashboard overflow issues by:
- Removed labels from branch and issue selectors (kept only repo label)
- Added new `IssueOpenedIcon` component to replace GitHub icon in issue selector
- Reduced `DescriptionTextarea` min-height from `160px` to `100px`
- Commented out `DeadlineChip` component (not currently used in bounties)

🦞 
  


 <br /> 


 > Want tembo to make any changes? Add a review or comment with `@tembo` and i'll get back to work! 


 <a href="https://app.tembo.io/tasks/9c3d0fac-ba3f-4f34-aa3f-ae2230697f06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/static/view/tembo-dark.png?v=2"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/static/view/tembo-light.png?v=2"><img alt="View on Tembo" src="https://internal.tembo.io/static/view/tembo-light.png?v=2" width="134" height="28"></picture></a> <a href="https://app.tembo.io/settings/models"><picture><source media="(prefers-color-scheme: dark)" srcset="https://internal.tembo.io/public/agent-button/claudeCode:claude-opus-4-6?theme=dark&v=11"><source media="(prefers-color-scheme: light)" srcset="https://internal.tembo.io/public/agent-button/claudeCode:claude-opus-4-6?theme=light&v=11"><img alt="View Agent Settings" src="https://internal.tembo.io/public/agent-button/claudeCode:claude-opus-4-6?theme=light&v=11" height="28"></picture></a> 