### PR TITLE
improve(waitlist): add shareable trading card for each waitlist member

### DIFF
--- a/apps/web/src/components/landing/waitlist-demo.tsx
+++ b/apps/web/src/components/landing/waitlist-demo.tsx
@@ -62,9 +62,18 @@ interface CardData {
   joinedDate: string;
 }
 
+function openShareIntent(text: string) {
+  window.open(
+    `https://x.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent('https://bounty.new')}`,
+    '_blank',
+    'noopener,noreferrer'
+  );
+}
+
 function useWaitlistSubmission(): WaitlistHookResult {
   const { celebrate } = useConfetti();
   const [success, setSuccess] = useState(false);
+  const [position, setPosition] = useState<number | null>(null);
   const [rateLimitInfo, setRateLimitInfo] = useState<RateLimitInfo | null>(
     null
   );
@@ -84,15 +93,19 @@ function useWaitlistSubmission(): WaitlistHookResult {
         throw new Error(data.error || 'Failed to join waitlist');
       }
 
-      return data;
+      return data as { success: boolean; position?: number; message?: string };
     },
-    onSuccess: (_data, variables) => {
+    onSuccess: (data, variables) => {
       setSuccess(true);
+
+      const pos = data.position;
+      if (pos) setPosition(pos);
 
       const cookieData: WaitlistCookieData = {
         submitted: true,
         timestamp: new Date().toISOString(),
         email: btoa(variables.email).substring(0, 16),
+        position: pos,
       };
       writeStoredWaitlist(cookieData);
 
@@ -118,7 +131,7 @@ function useWaitlistSubmission(): WaitlistHookResult {
     },
   });
 
-  return { mutate, isPending, success, setSuccess, rateLimitInfo };
+  return { mutate, isPending, success, setSuccess, rateLimitInfo, position };
 }
 
 interface WaitlistPageProps {
@@ -177,29 +190,24 @@ function WaitlistPage({ compact = false }: WaitlistPageProps) {
     generateFingerprint();
   }, []);
 
-  // Capture position once waitlist count updates after joining
+  // Build card data from API position (primary) or waitlistCount (fallback)
   useEffect(() => {
-    if (waitlistSubmission.success && waitlistCount !== undefined && !cardData) {
-      const position = waitlistCount;
-      const tier = getTier(position);
+    const pos = waitlistSubmission.position ?? (waitlistSubmission.success ? waitlistCount : undefined);
+    if (waitlistSubmission.success && pos && !cardData) {
+      const tier = getTier(pos);
       const joinedDate = new Date().toLocaleDateString('en-US', {
         month: 'short',
         day: 'numeric',
         year: 'numeric',
       });
-      setCardData({ position, tier, joinedDate });
+      setCardData({ position: pos, tier, joinedDate });
       const stored = readStoredWaitlist();
-      if (stored) writeStoredWaitlist({ ...stored, position });
+      if (stored && !stored.position) writeStoredWaitlist({ ...stored, position: pos });
     }
-  }, [waitlistSubmission.success, waitlistCount, cardData]);
+  }, [waitlistSubmission.success, waitlistSubmission.position, waitlistCount, cardData]);
 
   function handleShareCard(position: number) {
-    const text = `I'm #${position} on the waitlist for bounty.new — the fastest way to hire devs to fix your code. Join me 👇`;
-    window.open(
-      `https://x.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent('https://bounty.new')}`,
-      '_blank',
-      'noopener,noreferrer'
-    );
+    openShareIntent(`I'm #${position} on the waitlist for bounty.new — the fastest way to hire devs to fix your code. Join me 👇`);
   }
 
   function joinWaitlist({ email }: FormSchema) {
@@ -388,16 +396,7 @@ function WaitlistPage({ compact = false }: WaitlistPageProps) {
                   </p>
                   <button
                     type="button"
-                    onClick={() => {
-                      const text =
-                        "I just joined the waitlist for bounty.new — the fastest way to hire developers to fix your code. Join me 👇";
-                      const url = "https://bounty.new";
-                      window.open(
-                        `https://x.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent(url)}`,
-                        "_blank",
-                        "noopener,noreferrer"
-                      );
-                    }}
+                    onClick={() => openShareIntent("I just joined the waitlist for bounty.new — the fastest way to hire developers to fix your code. Join me 👇")}
                     className="inline-flex items-center gap-2 px-3 py-1.5 rounded-lg bg-foreground text-background text-xs font-medium hover:opacity-90 transition-opacity"
                   >
                     <svg
@@ -514,11 +513,13 @@ function WaitlistPage({ compact = false }: WaitlistPageProps) {
                     />
                   </div>
                 </div>
-                <span
-                  className={`${compact ? 'text-[10px]' : 'text-xs'} text-text-muted`}
-                >
-                  <NumberFlow value={waitlistCount ?? 0} />+ on the list
-                </span>
+                {waitlistCount !== undefined && (
+                  <span
+                    className={`${compact ? 'text-[10px]' : 'text-xs'} text-text-muted`}
+                  >
+                    <NumberFlow value={waitlistCount} />+ on the list
+                  </span>
+                )}
               </div>
             </>
           )}

--- a/apps/web/src/types/waitlist.ts
+++ b/apps/web/src/types/waitlist.ts
@@ -31,4 +31,5 @@ export interface WaitlistHookResult {
   success: boolean;
   setSuccess: (success: boolean) => void;
   rateLimitInfo: RateLimitInfo | null;
+  position: number | null;
 }


### PR DESCRIPTION
BOUNTY.NEW

## What this PR does

Improves the waitlist submitted state with a personalised trading card and share CTA.

Closes #231

### Trading card
Each user gets a personalised card after joining the waitlist:
- **Position number** (#247 etc.) captured directly from the API response
- **Tier badge** based on position: Pioneer (≤100, amber) / Early Adopter (≤500, purple) / Member (blue)
- Dark gradient card with subtle grid lines and per-tier glow border
- **Share card** button — tweets a personalised message: _I'm #247 on the waitlist for bounty.new..._
- Position persisted to localStorage so returning visitors see their card

### Bug fixes (addressing CodeRabbit review)
- **Position accuracy**: `onSuccess` now reads `data.position` from the API response (the authoritative assigned position) instead of using `waitlistCount` (the total member count, which can differ due to timing or gaps)
- **No "0+ on the list" flash**: social proof count is now hidden while `waitlistCount` is loading, matching the badge behaviour above
- **No duplicate `window.open` logic**: extracted `openShareIntent()` helper used by both the trading card and the fallback share button

### Fallback
The plain "Share on X" box is shown while card data is resolving. Returning visitors with a stored position see their card immediately without waiting for the API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Waitlist position is now visible to users upon joining, with tier assignment based on position
  * New shareable trading card displays user's position, tier, and join date
  * Added native share functionality to allow users to promote their waitlist status

<!-- end of auto-generated comment: release notes by coderabbit.ai -->