### PR TITLE
Polish waitlist submitted state

### DIFF
--- a/apps/web/src/components/landing/waitlist-demo.tsx
+++ b/apps/web/src/components/landing/waitlist-demo.tsx
@@ -5,6 +5,7 @@ import { Button } from '@bounty/ui/components/button';
 import NumberFlow from '@bounty/ui/components/number-flow';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { GithubIcon } from '@bounty/ui/components/icons/huge/github';
+import { CheckCircle2, Clipboard, Share2 } from 'lucide-react';
 import Image from 'next/image';
 import { useState } from 'react';
 import { useMountEffect } from '@bounty/ui';
@@ -17,7 +18,9 @@ import { MockBrowser } from './mockup';
 const WAITLIST_STORAGE_KEY = 'waitlist_data';
 
 function readStoredWaitlist(): WaitlistCookieData | null {
-  if (typeof window === 'undefined') return null;
+  if (typeof window === 'undefined') {
+    return null;
+  }
   try {
     const raw = window.localStorage.getItem(WAITLIST_STORAGE_KEY);
     return raw ? (JSON.parse(raw) as WaitlistCookieData) : null;
@@ -27,7 +30,9 @@ function readStoredWaitlist(): WaitlistCookieData | null {
 }
 
 function writeStoredWaitlist(data: WaitlistCookieData) {
-  if (typeof window === 'undefined') return;
+  if (typeof window === 'undefined') {
+    return;
+  }
   try {
     window.localStorage.setItem(WAITLIST_STORAGE_KEY, JSON.stringify(data));
   } catch {
@@ -105,6 +110,7 @@ interface WaitlistPageProps {
 
 function WaitlistPage({ compact = false }: WaitlistPageProps) {
   const waitlistSubmission = useWaitlistSubmission();
+  const [copied, setCopied] = useState(false);
 
   useMountEffect(() => {
     const stored = readStoredWaitlist();
@@ -125,6 +131,35 @@ function WaitlistPage({ compact = false }: WaitlistPageProps) {
     retryDelay: 1000,
   });
   const waitlistCount = waitlistCountQuery.data?.count ?? 0;
+  const hasWaitlistCount = waitlistCount > 0;
+  const waitlistCountLabel = hasWaitlistCount
+    ? `#${waitlistCount.toLocaleString()}`
+    : 'Reserved';
+  const shareText =
+    'I joined the bounty.new early access list to turn GitHub issues into paid work.';
+
+  async function copyWaitlistStatus() {
+    if (typeof navigator === 'undefined' || !navigator.clipboard) {
+      return;
+    }
+
+    await navigator.clipboard.writeText(
+      `${shareText} ${hasWaitlistCount ? `Current waitlist: ${waitlistCountLabel}. ` : ''}https://bounty.new`
+    );
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1800);
+  }
+
+  function shareWaitlistStatus() {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const url = new URL('https://x.com/intent/tweet');
+    url.searchParams.set('text', shareText);
+    url.searchParams.set('url', 'https://bounty.new');
+    window.open(url.toString(), '_blank', 'noopener,noreferrer');
+  }
 
   return (
     <div className="h-full bg-background overflow-auto">
@@ -150,43 +185,84 @@ function WaitlistPage({ compact = false }: WaitlistPageProps) {
 
           {/* Success state */}
           {waitlistSubmission.success ? (
-            <div className={`text-left ${compact ? 'py-2' : 'py-4'}`}>
-              <div
-                className={`inline-flex items-center justify-center ${compact ? 'w-8 h-8 mb-2' : 'w-12 h-12 mb-4'} rounded-full bg-brand-accent/10`}
-              >
-                <svg
-                  className={`${compact ? 'w-4 h-4' : 'w-6 h-6'} text-brand-accent`}
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
+            <div
+              className={`relative overflow-hidden border border-border-subtle bg-surface-1/90 shadow-[0_18px_60px_rgba(0,0,0,0.18)] ${
+                compact ? 'rounded-xl p-4' : 'rounded-2xl p-6'
+              }`}
+            >
+              <div className="relative">
+                <div className="flex items-start justify-between gap-3">
+                  <div
+                    className={`flex items-center justify-center rounded-full border border-brand-accent/30 bg-brand-accent/10 text-brand-accent ${
+                      compact ? 'h-9 w-9' : 'h-12 w-12'
+                    }`}
+                  >
+                    <CheckCircle2 className={compact ? 'h-5 w-5' : 'h-6 w-6'} />
+                  </div>
+                  <div className="inline-flex items-center rounded-full border border-brand-accent/25 bg-brand-accent/10 px-2.5 py-1 text-[11px] text-brand-accent-muted">
+                    Confirmed
+                  </div>
+                </div>
+
+                <div className={compact ? 'mt-3' : 'mt-5'}>
+                  <h2
+                    className={`${compact ? 'text-base' : 'text-xl'} font-medium text-foreground tracking-tight`}
+                  >
+                    You're on the list
+                  </h2>
+                  <p
+                    className={`${compact ? 'mt-1 text-xs' : 'mt-2 text-sm'} text-text-muted leading-relaxed`}
+                  >
+                    Your early access spot is saved. We'll reach out when it's
+                    your turn.
+                  </p>
+                </div>
+
+                <div
+                  className={`grid grid-cols-2 gap-2 ${compact ? 'mt-4' : 'mt-5'}`}
                 >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2.5}
-                    d="M5 13l4 4L19 7"
-                  />
-                </svg>
-              </div>
-              <h2
-                className={`${compact ? 'text-base' : 'text-xl'} font-medium text-foreground mb-1`}
-              >
-                You're on the list
-              </h2>
-              <p
-                className={`${compact ? 'text-xs mb-3' : 'text-sm mb-6'} text-text-muted`}
-              >
-                We'll reach out when it's your turn.
-              </p>
-              <div
-                className={`inline-flex items-center gap-2 ${compact ? 'px-2 py-1' : 'px-3 py-1.5'} rounded-full bg-surface-1 border border-border-subtle`}
-              >
-                <span className="text-xs text-text-muted">Position</span>
-                <span
-                  className={`${compact ? 'text-xs' : 'text-sm'} font-medium text-brand-accent-muted`}
-                >
-                  #{waitlistCount}
-                </span>
+                  <div className="rounded-lg border border-border-subtle bg-background/70 p-3">
+                    <p className="text-[11px] text-text-muted">
+                      Current waitlist
+                    </p>
+                    <p
+                      className={`${compact ? 'text-lg' : 'text-2xl'} font-medium text-foreground tabular-nums`}
+                    >
+                      {waitlistCountLabel}
+                    </p>
+                  </div>
+                  <div className="rounded-lg border border-border-subtle bg-background/70 p-3">
+                    <p className="text-[11px] text-text-muted">Status</p>
+                    <p
+                      className={`${compact ? 'text-sm' : 'text-base'} font-medium text-foreground`}
+                    >
+                      Invite pending
+                    </p>
+                  </div>
+                </div>
+
+                {!compact && (
+                  <div className="mt-5 flex flex-wrap items-center gap-2">
+                    <Button
+                      className="h-8 gap-1.5 bg-background/70 px-3 text-xs text-text-secondary hover:text-foreground"
+                      onClick={copyWaitlistStatus}
+                      size="sm"
+                      variant="outline"
+                    >
+                      <Clipboard className="h-3.5 w-3.5" />
+                      {copied ? 'Copied' : 'Copy update'}
+                    </Button>
+                    <Button
+                      className="h-8 gap-1.5 bg-background/70 px-3 text-xs text-text-secondary hover:text-foreground"
+                      onClick={shareWaitlistStatus}
+                      size="sm"
+                      variant="outline"
+                    >
+                      <Share2 className="h-3.5 w-3.5" />
+                      Share
+                    </Button>
+                  </div>
+                )}
               </div>
             </div>
           ) : (

--- a/apps/web/src/components/landing/waitlist-demo.tsx
+++ b/apps/web/src/components/landing/waitlist-demo.tsx
@@ -143,11 +143,15 @@ function WaitlistPage({ compact = false }: WaitlistPageProps) {
       return;
     }
 
-    await navigator.clipboard.writeText(
-      `${shareText} ${hasWaitlistCount ? `Current waitlist: ${waitlistCountLabel}. ` : ''}https://bounty.new`
-    );
-    setCopied(true);
-    window.setTimeout(() => setCopied(false), 1800);
+    try {
+      await navigator.clipboard.writeText(
+        `${shareText} ${hasWaitlistCount ? `Current waitlist: ${waitlistCountLabel}. ` : ''}https://bounty.new`
+      );
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1800);
+    } catch {
+      toast.error('Could not copy update. Please copy manually.');
+    }
   }
 
   function shareWaitlistStatus() {


### PR DESCRIPTION
Closes #231

@bountydotnew submit

## Summary
- Reworks the waitlist submitted state into a clearer confirmation panel
- Adds a confirmed badge, current waitlist/status details, and lightweight copy/share actions
- Keeps the compact landing mockup concise while reusing existing Button styling

## Verification
- npx --yes bun@1.2.17 x biome check apps/web/src/components/landing/waitlist-demo.tsx
- git diff --check
- Local landing page smoke check at http://localhost:3001 with .env.example placeholders
- npx --yes bun@1.2.17 check:web (fails on existing @bounty/ui path alias/type errors outside this change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Copy waitlist status to clipboard with temporary "Copied" confirmation and error toast on failure
  * Share waitlist via X/Twitter using a preset message
  * Added inline icons for copy/share/check actions

* **User Interface**
  * Redesigned waitlist success view with a bordered "Confirmed" card
  * "Current waitlist" panel shows formatted count or "Reserved" and an "Invite pending" panel
  * "Copy update" and "Share" buttons in non-compact layout

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bountydotnew/bounty.new/pull/289)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bountydotnew/bounty.new/pull/289)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->