### PR TITLE
Polish waitlist submitted state

### DIFF
--- a/apps/web/src/components/landing/waitlist-demo.tsx
+++ b/apps/web/src/components/landing/waitlist-demo.tsx
@@ -20,6 +20,10 @@ type StoredWaitlistData = WaitlistCookieData & {
   position?: number | null;
 };
 
+function normalizeWaitlistPosition(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
 function readStoredWaitlist(): StoredWaitlistData | null {
   if (typeof window === 'undefined') {
     return null;
@@ -33,10 +37,7 @@ function readStoredWaitlist(): StoredWaitlistData | null {
     const parsed = JSON.parse(raw) as StoredWaitlistData;
     return {
       ...parsed,
-      position:
-        typeof parsed.position === 'number' && Number.isFinite(parsed.position)
-          ? parsed.position
-          : null,
+      position: normalizeWaitlistPosition(parsed.position),
     };
   } catch {
     return null;
@@ -63,11 +64,7 @@ function useWaitlistSubmission() {
     mutationFn: () => trpcClient.earlyAccess.joinWaitlist.mutate(),
     onSuccess: (data) => {
       const nextPosition =
-        'position' in data &&
-        typeof data.position === 'number' &&
-        Number.isFinite(data.position)
-          ? data.position
-          : null;
+        'position' in data ? normalizeWaitlistPosition(data.position) : null;
       setSuccess(true);
       setPosition(nextPosition);
 

--- a/apps/web/src/components/landing/waitlist-demo.tsx
+++ b/apps/web/src/components/landing/waitlist-demo.tsx
@@ -16,18 +16,37 @@ import { MockBrowser } from './mockup';
 
 const WAITLIST_STORAGE_KEY = 'waitlist_data';
 
-function readStoredWaitlist(): WaitlistCookieData | null {
-  if (typeof window === 'undefined') return null;
+type StoredWaitlistData = WaitlistCookieData & {
+  position?: number | null;
+};
+
+function readStoredWaitlist(): StoredWaitlistData | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
   try {
     const raw = window.localStorage.getItem(WAITLIST_STORAGE_KEY);
-    return raw ? (JSON.parse(raw) as WaitlistCookieData) : null;
+    if (!raw) {
+      return null;
+    }
+
+    const parsed = JSON.parse(raw) as StoredWaitlistData;
+    return {
+      ...parsed,
+      position:
+        typeof parsed.position === 'number' && Number.isFinite(parsed.position)
+          ? parsed.position
+          : null,
+    };
   } catch {
     return null;
   }
 }
 
-function writeStoredWaitlist(data: WaitlistCookieData) {
-  if (typeof window === 'undefined') return;
+function writeStoredWaitlist(data: StoredWaitlistData) {
+  if (typeof window === 'undefined') {
+    return;
+  }
   try {
     window.localStorage.setItem(WAITLIST_STORAGE_KEY, JSON.stringify(data));
   } catch {
@@ -38,16 +57,25 @@ function writeStoredWaitlist(data: WaitlistCookieData) {
 function useWaitlistSubmission() {
   const { celebrate } = useConfetti();
   const [success, setSuccess] = useState(false);
+  const [position, setPosition] = useState<number | null>(null);
 
   const { mutate, isPending } = useMutation({
     mutationFn: () => trpcClient.earlyAccess.joinWaitlist.mutate(),
-    onSuccess: () => {
+    onSuccess: (data) => {
+      const nextPosition =
+        'position' in data &&
+        typeof data.position === 'number' &&
+        Number.isFinite(data.position)
+          ? data.position
+          : null;
       setSuccess(true);
+      setPosition(nextPosition);
 
-      const cookieData: WaitlistCookieData = {
+      const cookieData: StoredWaitlistData = {
         submitted: true,
         timestamp: new Date().toISOString(),
         email: '',
+        position: nextPosition,
       };
       writeStoredWaitlist(cookieData);
 
@@ -96,7 +124,7 @@ function useWaitlistSubmission() {
     },
   });
 
-  return { mutate, isPending, success, setSuccess };
+  return { mutate, isPending, position, setPosition, success, setSuccess };
 }
 
 interface WaitlistPageProps {
@@ -110,6 +138,7 @@ function WaitlistPage({ compact = false }: WaitlistPageProps) {
     const stored = readStoredWaitlist();
     if (stored?.submitted) {
       waitlistSubmission.setSuccess(true);
+      waitlistSubmission.setPosition(stored.position ?? null);
     }
   });
 
@@ -121,10 +150,15 @@ function WaitlistPage({ compact = false }: WaitlistPageProps) {
 
   const waitlistCountQuery = useQuery({
     ...trpc.earlyAccess.getWaitlistCount.queryOptions(),
+    enabled: !waitlistSubmission.success,
     retry: 2,
     retryDelay: 1000,
   });
-  const waitlistCount = waitlistCountQuery.data?.count ?? 0;
+  const waitlistCount =
+    typeof waitlistCountQuery.data?.count === 'number'
+      ? waitlistCountQuery.data.count
+      : null;
+  const position = waitlistSubmission.position;
 
   return (
     <div className="h-full bg-background overflow-auto">
@@ -150,43 +184,79 @@ function WaitlistPage({ compact = false }: WaitlistPageProps) {
 
           {/* Success state */}
           {waitlistSubmission.success ? (
-            <div className={`text-left ${compact ? 'py-2' : 'py-4'}`}>
+            <div className={`text-left ${compact ? 'py-1' : 'py-2'}`}>
               <div
-                className={`inline-flex items-center justify-center ${compact ? 'w-8 h-8 mb-2' : 'w-12 h-12 mb-4'} rounded-full bg-brand-accent/10`}
+                className={`rounded-[18px] border border-border-subtle bg-surface-1/70 ${compact ? 'p-3' : 'p-5'} shadow-[0_18px_60px_rgba(0,0,0,0.16)]`}
               >
-                <svg
-                  className={`${compact ? 'w-4 h-4' : 'w-6 h-6'} text-brand-accent`}
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
+                <div className="mb-3 flex items-center gap-2">
+                  <div
+                    className={`flex shrink-0 items-center justify-center rounded-full bg-brand-accent/15 ${compact ? 'size-7' : 'size-9'}`}
+                  >
+                    <svg
+                      aria-hidden="true"
+                      className={`${compact ? 'size-3.5' : 'size-4.5'} text-brand-accent`}
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2.5}
+                        d="M5 13l4 4L19 7"
+                      />
+                    </svg>
+                  </div>
+                  <span
+                    className={`rounded-full border border-brand-accent/20 bg-brand-accent/10 font-medium text-brand-accent ${compact ? 'px-2 py-0.5 text-[10px]' : 'px-2.5 py-1 text-xs'}`}
+                  >
+                    Confirmed
+                  </span>
+                </div>
+
+                <h2
+                  className={`${compact ? 'mb-1 text-base' : 'mb-2 text-xl'} font-medium text-foreground`}
                 >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2.5}
-                    d="M5 13l4 4L19 7"
-                  />
-                </svg>
-              </div>
-              <h2
-                className={`${compact ? 'text-base' : 'text-xl'} font-medium text-foreground mb-1`}
-              >
-                You're on the list
-              </h2>
-              <p
-                className={`${compact ? 'text-xs mb-3' : 'text-sm mb-6'} text-text-muted`}
-              >
-                We'll reach out when it's your turn.
-              </p>
-              <div
-                className={`inline-flex items-center gap-2 ${compact ? 'px-2 py-1' : 'px-3 py-1.5'} rounded-full bg-surface-1 border border-border-subtle`}
-              >
-                <span className="text-xs text-text-muted">Position</span>
-                <span
-                  className={`${compact ? 'text-xs' : 'text-sm'} font-medium text-brand-accent-muted`}
+                  You're on the list
+                </h2>
+                <p
+                  className={`${compact ? 'mb-3 text-xs' : 'mb-5 text-sm'} text-text-muted leading-relaxed`}
                 >
-                  #{waitlistCount}
-                </span>
+                  Your spot is saved. We'll email you when early access opens.
+                </p>
+
+                <div
+                  className={`grid grid-cols-2 overflow-hidden rounded-xl border border-border-subtle bg-background/70 ${compact ? 'text-xs' : 'text-sm'}`}
+                >
+                  <div className={`${compact ? 'p-2.5' : 'p-3.5'}`}>
+                    <div className="mb-1 text-[10px] uppercase tracking-[0.12em] text-text-muted">
+                      Position
+                    </div>
+                    <div
+                      className={`${compact ? 'text-base' : 'text-lg'} font-medium text-foreground`}
+                    >
+                      {position === null ? (
+                        'Reserved'
+                      ) : (
+                        <>
+                          #<NumberFlow value={position} />
+                        </>
+                      )}
+                    </div>
+                  </div>
+                  <div
+                    className={`border-l border-border-subtle ${compact ? 'p-2.5' : 'p-3.5'}`}
+                  >
+                    <div className="mb-1 text-[10px] uppercase tracking-[0.12em] text-text-muted">
+                      Status
+                    </div>
+                    <div
+                      className={`${compact ? 'text-base' : 'text-lg'} font-medium text-foreground`}
+                    >
+                      Invite pending
+                    </div>
+                  </div>
+                </div>
               </div>
             </div>
           ) : (
@@ -267,18 +337,25 @@ function WaitlistPage({ compact = false }: WaitlistPageProps) {
                 <span
                   className={`${compact ? 'text-[10px]' : 'text-xs'} text-text-muted`}
                 >
-                  <NumberFlow value={waitlistCount} />+ on the list
+                  {waitlistCount === null ? (
+                    'Builders are joining'
+                  ) : (
+                    <>
+                      <NumberFlow value={waitlistCount} />+ on the list
+                    </>
+                  )}
                 </span>
               </div>
             </>
           )}
 
-          {/* Footer note */}
-          <p
-            className={`${compact ? 'text-[10px] mt-4' : 'text-xs mt-8'} text-text-muted`}
-          >
-            No spam, unsubscribe anytime.
-          </p>
+          {!waitlistSubmission.success && (
+            <p
+              className={`${compact ? 'text-[10px] mt-4' : 'text-xs mt-8'} text-text-muted`}
+            >
+              No spam, unsubscribe anytime.
+            </p>
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
BOUNTY.NEW

## Summary
- Reworks the waitlist submitted state into a compact confirmation panel that matches the existing dark, restrained landing mockup
- Persists and restores the actual waitlist position returned by the join mutation when it is available
- Avoids showing a misleading `#0` waitlist fallback when the count query has not returned

Closes #231

@bountydotnew submit

amber-harbor-213

## Verification
- `npx --yes bun@1.2.17 x biome check apps/web/src/components/landing/waitlist-demo.tsx`
- `npx --yes bun@1.2.17 x tsc --noEmit -p apps/web/tsconfig.json --pretty false`
- Desktop and mobile local screenshots with seeded submitted waitlist data
- `npx --yes bun@1.2.17 run check:web` still fails on existing `@bounty/ui` path alias/type errors unrelated to this change (`@/stores/confetti-store`, `@/hooks/use-initial-data`, `@/utils/trpc`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Waitlist positions are now persisted and displayed to users after successfully joining
  * Success screen displays queue position and invite pending status

* **Improvements**
  * Updated social proof messaging and subscription disclaimer visibility based on waitlist status
  * Enhanced success state UI with position information instead of count-based layout

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bountydotnew/bounty.new/pull/291)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->