### PR TITLE
feat: improve waitlist submitted state

### DIFF
--- a/apps/web/src/components/landing/waitlist-demo.tsx
+++ b/apps/web/src/components/landing/waitlist-demo.tsx
@@ -5,6 +5,7 @@ import { Button } from '@bounty/ui/components/button';
 import NumberFlow from '@bounty/ui/components/number-flow';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { GithubIcon } from '@bounty/ui/components/icons/huge/github';
+import { CheckCircle2, Clock3, Sparkles } from 'lucide-react';
 import Image from 'next/image';
 import { useState } from 'react';
 import { useMountEffect } from '@bounty/ui';
@@ -17,7 +18,9 @@ import { MockBrowser } from './mockup';
 const WAITLIST_STORAGE_KEY = 'waitlist_data';
 
 function readStoredWaitlist(): WaitlistCookieData | null {
-  if (typeof window === 'undefined') return null;
+  if (typeof window === 'undefined') {
+    return null;
+  }
   try {
     const raw = window.localStorage.getItem(WAITLIST_STORAGE_KEY);
     return raw ? (JSON.parse(raw) as WaitlistCookieData) : null;
@@ -27,7 +30,9 @@ function readStoredWaitlist(): WaitlistCookieData | null {
 }
 
 function writeStoredWaitlist(data: WaitlistCookieData) {
-  if (typeof window === 'undefined') return;
+  if (typeof window === 'undefined') {
+    return;
+  }
   try {
     window.localStorage.setItem(WAITLIST_STORAGE_KEY, JSON.stringify(data));
   } catch {
@@ -38,11 +43,13 @@ function writeStoredWaitlist(data: WaitlistCookieData) {
 function useWaitlistSubmission() {
   const { celebrate } = useConfetti();
   const [success, setSuccess] = useState(false);
+  const [position, setPosition] = useState<number | null>(null);
 
   const { mutate, isPending } = useMutation({
     mutationFn: () => trpcClient.earlyAccess.joinWaitlist.mutate(),
-    onSuccess: () => {
+    onSuccess: (data) => {
       setSuccess(true);
+      setPosition('position' in data ? data.position : null);
 
       const cookieData: WaitlistCookieData = {
         submitted: true,
@@ -96,7 +103,7 @@ function useWaitlistSubmission() {
     },
   });
 
-  return { mutate, isPending, success, setSuccess };
+  return { mutate, isPending, position, success, setSuccess };
 }
 
 interface WaitlistPageProps {
@@ -125,6 +132,8 @@ function WaitlistPage({ compact = false }: WaitlistPageProps) {
     retryDelay: 1000,
   });
   const waitlistCount = waitlistCountQuery.data?.count ?? 0;
+  const waitlistPosition =
+    waitlistSubmission.position ?? waitlistCountQuery.data?.count ?? null;
 
   return (
     <div className="h-full bg-background overflow-auto">
@@ -150,43 +159,74 @@ function WaitlistPage({ compact = false }: WaitlistPageProps) {
 
           {/* Success state */}
           {waitlistSubmission.success ? (
-            <div className={`text-left ${compact ? 'py-2' : 'py-4'}`}>
+            <div
+              className={`relative overflow-hidden rounded-[22px] bg-surface-1 shadow-[0_22px_70px_rgba(0,0,0,0.22),inset_0_1px_0_rgba(255,255,255,0.06)] ${compact ? 'p-3' : 'p-5'}`}
+            >
+              <div className="pointer-events-none absolute -right-12 -top-14 h-32 w-32 rounded-full bg-brand-accent/10 blur-2xl" />
+              <div className="pointer-events-none absolute -bottom-16 left-6 h-28 w-28 rounded-full bg-brand-primary/10 blur-2xl" />
+
               <div
-                className={`inline-flex items-center justify-center ${compact ? 'w-8 h-8 mb-2' : 'w-12 h-12 mb-4'} rounded-full bg-brand-accent/10`}
+                className={`relative flex ${compact ? 'items-start gap-2' : 'items-center gap-3'}`}
               >
-                <svg
-                  className={`${compact ? 'w-4 h-4' : 'w-6 h-6'} text-brand-accent`}
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
+                <div
+                  className={`grid shrink-0 place-items-center rounded-2xl bg-brand-accent/12 text-brand-accent shadow-[0_0_0_1px_rgba(74,222,0,0.14),0_12px_28px_rgba(74,222,0,0.12)] ${compact ? 'size-9' : 'size-12'}`}
                 >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2.5}
-                    d="M5 13l4 4L19 7"
-                  />
-                </svg>
+                  <CheckCircle2 className={compact ? 'size-4' : 'size-6'} />
+                </div>
+                <div className="min-w-0">
+                  <p
+                    className={`mb-1 inline-flex items-center gap-1 rounded-full bg-brand-accent/10 px-2 py-0.5 font-medium text-brand-accent ${compact ? 'text-[10px]' : 'text-xs'}`}
+                  >
+                    <Sparkles className={compact ? 'size-2.5' : 'size-3'} />
+                    Early access reserved
+                  </p>
+                  <h2
+                    className={`text-balance font-display text-foreground ${compact ? 'text-lg leading-5' : 'text-2xl leading-7'}`}
+                  >
+                    You're on the list
+                  </h2>
+                </div>
               </div>
-              <h2
-                className={`${compact ? 'text-base' : 'text-xl'} font-medium text-foreground mb-1`}
-              >
-                You're on the list
-              </h2>
-              <p
-                className={`${compact ? 'text-xs mb-3' : 'text-sm mb-6'} text-text-muted`}
-              >
-                We'll reach out when it's your turn.
-              </p>
+
               <div
-                className={`inline-flex items-center gap-2 ${compact ? 'px-2 py-1' : 'px-3 py-1.5'} rounded-full bg-surface-1 border border-border-subtle`}
+                className={`relative ${compact ? 'mt-3 rounded-2xl p-3' : 'mt-5 rounded-[18px] p-4'} bg-background/70 shadow-[inset_0_0_0_1px_rgba(255,255,255,0.06)]`}
               >
-                <span className="text-xs text-text-muted">Position</span>
-                <span
-                  className={`${compact ? 'text-xs' : 'text-sm'} font-medium text-brand-accent-muted`}
-                >
-                  #{waitlistCount}
-                </span>
+                <div className="flex items-end justify-between gap-3">
+                  <div>
+                    <p
+                      className={`font-medium uppercase tracking-[0.18em] text-text-muted ${compact ? 'text-[9px]' : 'text-[10px]'}`}
+                    >
+                      Queue position
+                    </p>
+                    <p
+                      className={`font-display text-foreground tabular-nums ${compact ? 'mt-0.5 text-3xl leading-none' : 'mt-1 text-5xl leading-none'}`}
+                    >
+                      {waitlistPosition ? `#${waitlistPosition}` : 'Saved'}
+                    </p>
+                  </div>
+                  <div
+                    className={`rounded-full bg-surface-1 px-2.5 py-1 font-medium text-brand-accent shadow-[0_0_0_1px_rgba(255,255,255,0.06)] ${compact ? 'text-[10px]' : 'text-xs'}`}
+                  >
+                    locked in
+                  </div>
+                </div>
+              </div>
+
+              <div
+                className={`relative grid ${compact ? 'mt-3 gap-2 text-[10px]' : 'mt-4 gap-3 text-xs'}`}
+              >
+                <div className="flex items-center gap-2 text-text-secondary">
+                  <Clock3 className="size-3.5 shrink-0 text-brand-accent-muted" />
+                  <span>We'll email you when your workspace is ready.</span>
+                </div>
+                {!compact && (
+                  <div className="flex items-center gap-2 text-text-muted">
+                    <span className="size-1.5 shrink-0 rounded-full bg-brand-primary" />
+                    <span>
+                      Your spot stays saved on this device for next visit.
+                    </span>
+                  </div>
+                )}
               </div>
             </div>
           ) : (


### PR DESCRIPTION
## Summary
- Redesign the waitlist submitted state with a stronger success panel, position block, and next-step messaging.
- Use the returned waitlist position when available and fall back to a neutral saved state instead of showing a fake zero.
- Keep compact and full landing demo layouts responsive.

## Verification
- bunx ultracite format apps/web/src/components/landing/waitlist-demo.tsx
- bun run --cwd apps/web typecheck

Closes #231

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Waitlist success screen now displays your actual queue position from the server (e.g., "`#42`"). Falls back to "Saved" if queue position data is unavailable.

* **UI/Style**
  * Redesigned success screen layout with updated icon styling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bountydotnew/bounty.new/pull/293?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->