### PR TITLE
Keep waitlist confirmation tied to the user's actual queue spot

### DIFF
--- a/apps/web/src/components/landing/waitlist-demo.tsx
+++ b/apps/web/src/components/landing/waitlist-demo.tsx
@@ -38,16 +38,24 @@ function writeStoredWaitlist(data: WaitlistCookieData) {
 function useWaitlistSubmission() {
   const { celebrate } = useConfetti();
   const [success, setSuccess] = useState(false);
+  const [position, setPosition] = useState<number | null>(null);
 
   const { mutate, isPending } = useMutation({
     mutationFn: () => trpcClient.earlyAccess.joinWaitlist.mutate(),
-    onSuccess: () => {
+    onSuccess: (result) => {
+      const waitlistPosition =
+        typeof result.position === 'number' && result.position > 0
+          ? result.position
+          : null;
+
       setSuccess(true);
+      setPosition(waitlistPosition);
 
       const cookieData: WaitlistCookieData = {
         submitted: true,
         timestamp: new Date().toISOString(),
         email: '',
+        position: waitlistPosition,
       };
       writeStoredWaitlist(cookieData);
 
@@ -96,7 +104,7 @@ function useWaitlistSubmission() {
     },
   });
 
-  return { mutate, isPending, success, setSuccess };
+  return { mutate, isPending, success, setSuccess, position, setPosition };
 }
 
 interface WaitlistPageProps {
@@ -110,6 +118,11 @@ function WaitlistPage({ compact = false }: WaitlistPageProps) {
     const stored = readStoredWaitlist();
     if (stored?.submitted) {
       waitlistSubmission.setSuccess(true);
+      waitlistSubmission.setPosition(
+        typeof stored.position === 'number' && stored.position > 0
+          ? stored.position
+          : null,
+      );
     }
   });
 
@@ -125,6 +138,9 @@ function WaitlistPage({ compact = false }: WaitlistPageProps) {
     retryDelay: 1000,
   });
   const waitlistCount = waitlistCountQuery.data?.count ?? 0;
+  const hasWaitlistPosition =
+    typeof waitlistSubmission.position === 'number' &&
+    waitlistSubmission.position > 0;
 
   return (
     <div className="h-full bg-background overflow-auto">
@@ -150,43 +166,93 @@ function WaitlistPage({ compact = false }: WaitlistPageProps) {
 
           {/* Success state */}
           {waitlistSubmission.success ? (
-            <div className={`text-left ${compact ? 'py-2' : 'py-4'}`}>
+            <div
+              aria-live="polite"
+              className={`text-left ${compact ? 'py-1' : 'py-2'}`}
+            >
               <div
-                className={`inline-flex items-center justify-center ${compact ? 'w-8 h-8 mb-2' : 'w-12 h-12 mb-4'} rounded-full bg-brand-accent/10`}
+                className={`relative overflow-hidden rounded-2xl border border-border-subtle bg-surface-1 ${compact ? 'p-3' : 'p-5'}`}
               >
-                <svg
-                  className={`${compact ? 'w-4 h-4' : 'w-6 h-6'} text-brand-accent`}
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
+                <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-brand-accent/60 to-transparent" />
+                <div
+                  className={`mb-4 flex items-start justify-between gap-3 ${compact ? 'mb-3' : ''}`}
                 >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2.5}
-                    d="M5 13l4 4L19 7"
-                  />
-                </svg>
-              </div>
-              <h2
-                className={`${compact ? 'text-base' : 'text-xl'} font-medium text-foreground mb-1`}
-              >
-                You're on the list
-              </h2>
-              <p
-                className={`${compact ? 'text-xs mb-3' : 'text-sm mb-6'} text-text-muted`}
-              >
-                We'll reach out when it's your turn.
-              </p>
-              <div
-                className={`inline-flex items-center gap-2 ${compact ? 'px-2 py-1' : 'px-3 py-1.5'} rounded-full bg-surface-1 border border-border-subtle`}
-              >
-                <span className="text-xs text-text-muted">Position</span>
-                <span
-                  className={`${compact ? 'text-xs' : 'text-sm'} font-medium text-brand-accent-muted`}
+                  <div
+                    className={`inline-flex items-center justify-center rounded-full bg-brand-accent/10 ${compact ? 'h-8 w-8' : 'h-12 w-12'}`}
+                  >
+                    <svg
+                      className={`${compact ? 'h-4 w-4' : 'h-6 w-6'} text-brand-accent`}
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2.5}
+                        d="M5 13l4 4L19 7"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    className={`inline-flex items-center gap-1.5 rounded-full border border-brand-accent/20 bg-brand-accent/10 text-brand-accent-muted ${compact ? 'px-2 py-1 text-[10px]' : 'px-2.5 py-1 text-xs'}`}
+                  >
+                    <span className="h-1.5 w-1.5 rounded-full bg-brand-accent" />
+                    Confirmed
+                  </div>
+                </div>
+                <h2
+                  className={`${compact ? 'mb-1 text-base' : 'mb-1 text-xl'} font-medium text-foreground`}
                 >
-                  #{waitlistCount}
-                </span>
+                  You're on the list
+                </h2>
+                <p
+                  className={`${compact ? 'mb-3 text-xs' : 'mb-5 text-sm'} text-text-muted leading-relaxed`}
+                >
+                  We'll email your invite as soon as early access opens for
+                  your account.
+                </p>
+                <div
+                  className={`mb-3 grid grid-cols-2 gap-2 ${compact ? '' : 'mb-4'}`}
+                >
+                  <div
+                    className={`rounded-xl border border-border-subtle bg-background/60 ${compact ? 'p-2' : 'p-3'}`}
+                  >
+                    <p className="text-[10px] uppercase tracking-wide text-text-muted">
+                      Queue spot
+                    </p>
+                    <p
+                      className={`${compact ? 'text-sm' : 'text-base'} font-medium text-foreground`}
+                    >
+                      {hasWaitlistPosition ? (
+                        <>
+                          #<NumberFlow value={waitlistSubmission.position ?? 0} />
+                        </>
+                      ) : (
+                        'Saved'
+                      )}
+                    </p>
+                  </div>
+                  <div
+                    className={`rounded-xl border border-border-subtle bg-background/60 ${compact ? 'p-2' : 'p-3'}`}
+                  >
+                    <p className="text-[10px] uppercase tracking-wide text-text-muted">
+                      Next step
+                    </p>
+                    <p
+                      className={`${compact ? 'text-sm' : 'text-base'} font-medium text-foreground`}
+                    >
+                      Check email
+                    </p>
+                  </div>
+                </div>
+                <p
+                  className={`${compact ? 'text-[10px]' : 'text-xs'} text-text-muted leading-relaxed`}
+                >
+                  {hasWaitlistPosition
+                    ? 'Your queue spot stays fixed as more builders join behind you.'
+                    : 'This demo keeps your confirmation on this device so you can come back later.'}
+                </p>
               </div>
             </div>
           ) : (

--- a/apps/web/src/components/landing/waitlist-demo.tsx
+++ b/apps/web/src/components/landing/waitlist-demo.tsx
@@ -6,10 +6,10 @@ import NumberFlow from '@bounty/ui/components/number-flow';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { GithubIcon } from '@bounty/ui/components/icons/huge/github';
 import Image from 'next/image';
-import { useState } from 'react';
-import { useMountEffect } from '@bounty/ui';
+import { useEffect, useState } from 'react';
 import { toast } from 'sonner';
 import { useConfetti } from '@/context/confetti-context';
+import { useSession } from '@/context/session-context';
 import type { WaitlistCookieData } from '@/types/waitlist';
 import { trpc, trpcClient } from '@/utils/trpc';
 import { MockBrowser } from './mockup';
@@ -43,13 +43,28 @@ function writeStoredWaitlist(data: WaitlistCookieData) {
 }
 
 /**
+ * Clears the persisted waitlist snapshot when it does not belong to the
+ * current authenticated user anymore.
+ */
+function clearStoredWaitlist() {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.removeItem(WAITLIST_STORAGE_KEY);
+  } catch {
+    // Ignore storage failures
+  }
+}
+
+/**
  * Submits the authenticated user to the waitlist and tracks the stable queue
  * position returned by the API for the confirmation state.
  */
 function useWaitlistSubmission() {
   const { celebrate } = useConfetti();
+  const { session } = useSession();
   const [success, setSuccess] = useState(false);
   const [position, setPosition] = useState<number | null>(null);
+  const currentUserEmail = session?.user?.email ?? '';
 
   const { mutate, isPending } = useMutation({
     mutationFn: () => trpcClient.earlyAccess.joinWaitlist.mutate(),
@@ -65,7 +80,7 @@ function useWaitlistSubmission() {
       const cookieData: WaitlistCookieData = {
         submitted: true,
         timestamp: new Date().toISOString(),
-        email: '',
+        email: currentUserEmail,
         position: waitlistPosition,
       };
       writeStoredWaitlist(cookieData);
@@ -126,19 +141,42 @@ interface WaitlistPageProps {
  * Renders the waitlist CTA and restores any locally saved confirmation state.
  */
 function WaitlistPage({ compact = false }: WaitlistPageProps) {
+  const { isPending: isSessionPending, session } = useSession();
   const waitlistSubmission = useWaitlistSubmission();
+  const currentUserEmail = session?.user?.email ?? null;
+  const { setPosition, setSuccess } = waitlistSubmission;
 
-  useMountEffect(() => {
-    const stored = readStoredWaitlist();
-    if (stored?.submitted) {
-      waitlistSubmission.setSuccess(true);
-      waitlistSubmission.setPosition(
-        typeof stored.position === 'number' && stored.position > 0
-          ? stored.position
-          : null,
-      );
+  useEffect(() => {
+    if (isSessionPending) {
+      return;
     }
-  });
+
+    const stored = readStoredWaitlist();
+
+    if (!stored?.submitted) {
+      return;
+    }
+
+    if (!currentUserEmail) {
+      setSuccess(false);
+      setPosition(null);
+      return;
+    }
+
+    if (stored.email !== currentUserEmail) {
+      clearStoredWaitlist();
+      setSuccess(false);
+      setPosition(null);
+      return;
+    }
+
+    setSuccess(true);
+    setPosition(
+      typeof stored.position === 'number' && stored.position > 0
+        ? stored.position
+        : null,
+    );
+  }, [currentUserEmail, isSessionPending, setPosition, setSuccess]);
 
   function joinWaitlist() {
     waitlistSubmission.mutate();

--- a/apps/web/src/components/landing/waitlist-demo.tsx
+++ b/apps/web/src/components/landing/waitlist-demo.tsx
@@ -77,13 +77,15 @@ function useWaitlistSubmission() {
       setSuccess(true);
       setPosition(waitlistPosition);
 
-      const cookieData: WaitlistCookieData = {
-        submitted: true,
-        timestamp: new Date().toISOString(),
-        email: currentUserEmail,
-        position: waitlistPosition,
-      };
-      writeStoredWaitlist(cookieData);
+      if (currentUserEmail) {
+        const cookieData: WaitlistCookieData = {
+          submitted: true,
+          timestamp: new Date().toISOString(),
+          email: currentUserEmail,
+          position: waitlistPosition,
+        };
+        writeStoredWaitlist(cookieData);
+      }
 
       celebrate();
       toast.success("You're on the list!");
@@ -182,7 +184,7 @@ function WaitlistPage({ compact = false }: WaitlistPageProps) {
     waitlistSubmission.mutate();
   }
 
-  const isFormDisabled = waitlistSubmission.isPending;
+  const isFormDisabled = waitlistSubmission.isPending || isSessionPending;
 
   const waitlistCountQuery = useQuery({
     ...trpc.earlyAccess.getWaitlistCount.queryOptions(),

--- a/apps/web/src/components/landing/waitlist-demo.tsx
+++ b/apps/web/src/components/landing/waitlist-demo.tsx
@@ -16,6 +16,10 @@ import { MockBrowser } from './mockup';
 
 const WAITLIST_STORAGE_KEY = 'waitlist_data';
 
+/**
+ * Restores the persisted waitlist confirmation so the demo can keep showing
+ * the user's saved queue state across refreshes.
+ */
 function readStoredWaitlist(): WaitlistCookieData | null {
   if (typeof window === 'undefined') return null;
   try {
@@ -26,6 +30,9 @@ function readStoredWaitlist(): WaitlistCookieData | null {
   }
 }
 
+/**
+ * Persists the latest waitlist confirmation snapshot for this browser.
+ */
 function writeStoredWaitlist(data: WaitlistCookieData) {
   if (typeof window === 'undefined') return;
   try {
@@ -35,6 +42,10 @@ function writeStoredWaitlist(data: WaitlistCookieData) {
   }
 }
 
+/**
+ * Submits the authenticated user to the waitlist and tracks the stable queue
+ * position returned by the API for the confirmation state.
+ */
 function useWaitlistSubmission() {
   const { celebrate } = useConfetti();
   const [success, setSuccess] = useState(false);
@@ -111,6 +122,9 @@ interface WaitlistPageProps {
   compact?: boolean;
 }
 
+/**
+ * Renders the waitlist CTA and restores any locally saved confirmation state.
+ */
 function WaitlistPage({ compact = false }: WaitlistPageProps) {
   const waitlistSubmission = useWaitlistSubmission();
 
@@ -355,6 +369,10 @@ interface WaitlistDemoProps {
   compact?: boolean;
 }
 
+/**
+ * Wraps the waitlist page in the landing-page browser mockup used on marketing
+ * surfaces.
+ */
 export function WaitlistDemo({ compact = false }: WaitlistDemoProps) {
   return (
     <MockBrowser

--- a/apps/web/src/types/waitlist.ts
+++ b/apps/web/src/types/waitlist.ts
@@ -15,6 +15,7 @@ export interface WaitlistCookieData {
   submitted: boolean;
   timestamp: string;
   email: string;
+  position?: number | null;
 }
 
 interface WaitlistResponse {

--- a/packages/api/src/routers/early-access.ts
+++ b/packages/api/src/routers/early-access.ts
@@ -1409,6 +1409,20 @@ export const earlyAccessRouter = router({
     });
 
     if (existingEntry) {
+      let position = existingEntry.position;
+      if (!position) {
+        const entriesBefore = await db
+          .select({ count: sql<number>`count(*)` })
+          .from(waitlist)
+          .where(sql`${waitlist.createdAt} < ${existingEntry.createdAt}`);
+        position = (entriesBefore[0]?.count ?? 0) + 1;
+
+        await db
+          .update(waitlist)
+          .set({ position })
+          .where(eq(waitlist.id as any, existingEntry.id) as any);
+      }
+
       // Update the entry with userId if not already set
       if (!existingEntry.userId) {
         await db
@@ -1421,6 +1435,7 @@ export const earlyAccessRouter = router({
         success: true,
         message: "You're already on the waitlist!",
         alreadyJoined: true,
+        position,
       };
     }
 

--- a/packages/api/src/routers/early-access.ts
+++ b/packages/api/src/routers/early-access.ts
@@ -1412,7 +1412,7 @@ export const earlyAccessRouter = router({
       let position = existingEntry.position;
       if (!position) {
         const entriesBefore = await db
-          .select({ count: sql<number>`count(*)` })
+          .select({ count: sql<number>`count(*)::int` })
           .from(waitlist)
           .where(sql`${waitlist.createdAt} < ${existingEntry.createdAt}`);
         position = (entriesBefore[0]?.count ?? 0) + 1;

--- a/packages/api/src/routers/early-access.ts
+++ b/packages/api/src/routers/early-access.ts
@@ -406,7 +406,7 @@ export const earlyAccessRouter = router({
 
           // Get position before update
           const [posResult] = await db
-            .select({ count: sql<number>`count(*)` })
+            .select({ count: sql<number>`count(*)::int` })
             .from(waitlist)
             .where(sql`${waitlist.createdAt} < ${existingEntry.createdAt}`);
           position = (posResult?.count ?? 0) + 1;
@@ -431,7 +431,7 @@ export const earlyAccessRouter = router({
           // Create new entry
           // Get position (count of existing entries)
           const [countResult] = await db
-            .select({ count: sql<number>`count(*)` })
+            .select({ count: sql<number>`count(*)::int` })
             .from(waitlist);
           position = (countResult?.count ?? 0) + 1;
 
@@ -663,7 +663,7 @@ export const earlyAccessRouter = router({
         let position = entry.position;
         if (!position) {
           const entriesBefore = await db
-            .select({ count: sql<number>`count(*)` })
+            .select({ count: sql<number>`count(*)::int` })
             .from(waitlist)
             .where(sql`${waitlist.createdAt} < ${entry.createdAt}`);
           position = (entriesBefore[0]?.count ?? 0) + 1;
@@ -733,7 +733,7 @@ export const earlyAccessRouter = router({
       if (!entry && userEmail) {
         // Calculate position (count of existing entries)
         const [countRes] = await db
-          .select({ count: sql<number>`count(*)` })
+          .select({ count: sql<number>`count(*)::int` })
           .from(waitlist);
         const position = (countRes?.count ?? 0) + 1;
 
@@ -768,7 +768,7 @@ export const earlyAccessRouter = router({
       let position = entry.position;
       if (!position) {
         const [posRes] = await db
-          .select({ count: sql<number>`count(*)` })
+          .select({ count: sql<number>`count(*)::int` })
           .from(waitlist)
           .where(sql`${waitlist.createdAt} < ${entry.createdAt}`);
         position = (posRes?.count ?? 0) + 1;


### PR DESCRIPTION
BOUNTY.NEW

## Summary
- persist the user-specific `position` returned by `joinWaitlist` in the landing waitlist demo
- return that same `position` for already-joined users so the confirmation state stays stable after rejoining
- redesign the submitted state around the real queue spot and next step instead of showing the live global waitlist count as a position

Closes #231

## Validation
- `git diff --check -- apps/web/src/components/landing/waitlist-demo.tsx apps/web/src/types/waitlist.ts packages/api/src/routers/early-access.ts`

## Notes
- I did not run `bun check:web` locally because this checkout does not have the repo's Bun runtime/dependencies installed in this environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can view their numeric position in the waitlist queue after joining.
  * Queue position is saved to the browser, restored across sessions, and cleared if the stored email no longer matches the signed-in user.
  * Success screen shows queue-specific wording and a “Queue spot” card that falls back to a “Saved” label when no valid position is available.

* **Bug Fixes**
  * Server now computes, returns, and persists a queue position for existing waitlist entries so the UI can display it.

* **Documentation**
  * Added comments describing persistence and restore behavior and the demo wrapper.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bountydotnew/bounty.new/pull/297?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->