### PR TITLE
Improve waitlist submitted state

### DIFF
--- a/apps/web/src/components/landing/waitlist-demo.tsx
+++ b/apps/web/src/components/landing/waitlist-demo.tsx
@@ -5,6 +5,7 @@ import { Button } from '@bounty/ui/components/button';
 import NumberFlow from '@bounty/ui/components/number-flow';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { GithubIcon } from '@bounty/ui/components/icons/huge/github';
+import { CheckCircle2, Clock3, MailCheck } from 'lucide-react';
 import Image from 'next/image';
 import { useState } from 'react';
 import { useMountEffect } from '@bounty/ui';
@@ -17,7 +18,9 @@ import { MockBrowser } from './mockup';
 const WAITLIST_STORAGE_KEY = 'waitlist_data';
 
 function readStoredWaitlist(): WaitlistCookieData | null {
-  if (typeof window === 'undefined') return null;
+  if (typeof window === 'undefined') {
+    return null;
+  }
   try {
     const raw = window.localStorage.getItem(WAITLIST_STORAGE_KEY);
     return raw ? (JSON.parse(raw) as WaitlistCookieData) : null;
@@ -27,7 +30,9 @@ function readStoredWaitlist(): WaitlistCookieData | null {
 }
 
 function writeStoredWaitlist(data: WaitlistCookieData) {
-  if (typeof window === 'undefined') return;
+  if (typeof window === 'undefined') {
+    return;
+  }
   try {
     window.localStorage.setItem(WAITLIST_STORAGE_KEY, JSON.stringify(data));
   } catch {
@@ -103,6 +108,94 @@ interface WaitlistPageProps {
   compact?: boolean;
 }
 
+function WaitlistSuccessState({
+  compact,
+  waitlistCount,
+}: {
+  compact: boolean;
+  waitlistCount: number;
+}) {
+  return (
+    <div className={compact ? 'py-1' : 'py-2'}>
+      <div
+        className={`relative overflow-hidden rounded-2xl border border-brand-accent/20 bg-surface-1 shadow-[0_18px_45px_rgba(0,0,0,0.08)] ${compact ? 'px-3 py-3' : 'px-5 py-5'}`}
+      >
+        <div className="absolute inset-x-0 top-0 h-1 bg-brand-accent" />
+        <div className="absolute -right-8 -top-10 h-24 w-24 rounded-full bg-brand-accent/10" />
+
+        <div
+          className={`relative flex ${compact ? 'items-start gap-2' : 'items-start gap-3'}`}
+        >
+          <div
+            className={`flex shrink-0 items-center justify-center rounded-full bg-brand-accent/10 text-brand-accent ${compact ? 'h-8 w-8' : 'h-11 w-11'}`}
+          >
+            <CheckCircle2
+              aria-hidden="true"
+              className={compact ? 'h-4 w-4' : 'h-6 w-6'}
+              strokeWidth={2.4}
+            />
+          </div>
+
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center justify-between gap-3">
+              <h2
+                className={`${compact ? 'text-sm' : 'text-lg'} font-medium leading-tight text-foreground`}
+              >
+                You're on the list
+              </h2>
+              <div
+                className={`shrink-0 rounded-full border border-border-subtle bg-background ${compact ? 'px-2 py-0.5' : 'px-2.5 py-1'}`}
+              >
+                <span className="sr-only">Waitlist position</span>
+                <span
+                  className={`${compact ? 'text-[10px]' : 'text-xs'} font-medium text-brand-accent-muted`}
+                >
+                  #{waitlistCount}
+                </span>
+              </div>
+            </div>
+
+            <p
+              className={`${compact ? 'mt-1 text-[11px]' : 'mt-2 text-sm'} text-text-muted leading-relaxed`}
+            >
+              We'll send your invite as soon as your spot opens.
+            </p>
+
+            {!compact && (
+              <div className="mt-5 grid grid-cols-2 gap-2">
+                <div className="rounded-xl border border-border-subtle bg-background/80 px-3 py-2">
+                  <MailCheck
+                    aria-hidden="true"
+                    className="mb-1 h-4 w-4 text-brand-accent"
+                  />
+                  <p className="text-xs font-medium text-foreground">
+                    Invite queued
+                  </p>
+                  <p className="mt-0.5 text-[11px] text-text-muted">
+                    No action needed
+                  </p>
+                </div>
+                <div className="rounded-xl border border-border-subtle bg-background/80 px-3 py-2">
+                  <Clock3
+                    aria-hidden="true"
+                    className="mb-1 h-4 w-4 text-brand-accent"
+                  />
+                  <p className="text-xs font-medium text-foreground">
+                    Saved locally
+                  </p>
+                  <p className="mt-0.5 text-[11px] text-text-muted">
+                    Reload-safe status
+                  </p>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function WaitlistPage({ compact = false }: WaitlistPageProps) {
   const waitlistSubmission = useWaitlistSubmission();
 
@@ -150,45 +243,10 @@ function WaitlistPage({ compact = false }: WaitlistPageProps) {
 
           {/* Success state */}
           {waitlistSubmission.success ? (
-            <div className={`text-left ${compact ? 'py-2' : 'py-4'}`}>
-              <div
-                className={`inline-flex items-center justify-center ${compact ? 'w-8 h-8 mb-2' : 'w-12 h-12 mb-4'} rounded-full bg-brand-accent/10`}
-              >
-                <svg
-                  className={`${compact ? 'w-4 h-4' : 'w-6 h-6'} text-brand-accent`}
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2.5}
-                    d="M5 13l4 4L19 7"
-                  />
-                </svg>
-              </div>
-              <h2
-                className={`${compact ? 'text-base' : 'text-xl'} font-medium text-foreground mb-1`}
-              >
-                You're on the list
-              </h2>
-              <p
-                className={`${compact ? 'text-xs mb-3' : 'text-sm mb-6'} text-text-muted`}
-              >
-                We'll reach out when it's your turn.
-              </p>
-              <div
-                className={`inline-flex items-center gap-2 ${compact ? 'px-2 py-1' : 'px-3 py-1.5'} rounded-full bg-surface-1 border border-border-subtle`}
-              >
-                <span className="text-xs text-text-muted">Position</span>
-                <span
-                  className={`${compact ? 'text-xs' : 'text-sm'} font-medium text-brand-accent-muted`}
-                >
-                  #{waitlistCount}
-                </span>
-              </div>
-            </div>
+            <WaitlistSuccessState
+              compact={compact}
+              waitlistCount={waitlistCount}
+            />
           ) : (
             <>
               {/* Join button */}


### PR DESCRIPTION
Resolves #231

## Summary
- Replaces the plain waitlist success block with a more polished submitted-state panel.
- Keeps compact and full-size landing demos supported with responsive spacing and typography.
- Uses lucide icons for the success, invite, and saved-status indicators instead of the inline check SVG.
- Keeps the local waitlist persistence behavior unchanged.

## Verification
- `bunx ultracite format apps/web/src/components/landing/waitlist-demo.tsx` -> passed
- `bunx tsc --noEmit --project apps/web/tsconfig.json --pretty false` -> passed
- `git diff --check` -> passed

Notes:
- `bun check:web` is still blocked by pre-existing `@bounty/ui` path-alias/type errors documented in `AGENTS.md`.
- Local Next dev server starts, but rendered QA could not complete because local env validation and browser storage restrictions blocked forcing the persisted submitted state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured the waitlist success screen component for improved code maintainability and organization.
  * Updated visual icons to use a consistent design system for better UI consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bountydotnew/bounty.new/pull/298?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->